### PR TITLE
Geolocation related changes

### DIFF
--- a/forestdatamodel/conversion/internal2mela.py
+++ b/forestdatamodel/conversion/internal2mela.py
@@ -55,6 +55,16 @@ def species_mapper(target):
     return target
 
 
+def stand_location_converter(target):
+    """in-place conversion """
+    target.geo_location = (
+        target.geo_location[0] / 1000,
+        target.geo_location[1] / 1000,
+        target.geo_location[2],
+        target.geo_location[3])
+    return target
+
+
 def mela_stratum(stratum):
     """Convert a TreeStratum so that enumerated category variables are converted to Mela value space"""
     result = copy(stratum)
@@ -86,4 +96,4 @@ def mela_stand(stand):
 
 default_mela_tree_mappers = [species_mapper]
 default_mela_stratum_mappers = [species_mapper]
-default_mela_stand_mappers = []
+default_mela_stand_mappers = [stand_location_converter]

--- a/forestdatamodel/model.py
+++ b/forestdatamodel/model.py
@@ -315,6 +315,11 @@ class ForestStand:
     # VMI stand number > 1 (meaning sivukoeala, auxiliary stand)
     auxiliary_stand: bool = False
 
+    monthly_temperatures: Optional[list[float]] = None
+    monthly_rainfall: Optional[list[float]] = None
+    sea_effect: Optional[float] = None
+    lake_effect: Optional[float] = None
+
     def __eq__(self, other: 'ForestStand'):
         return self.identifier == other.identifier
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ from setuptools import setup
 setup(
     name="forestdatamodel",
     description="Data classes and utilities for forest stand, tree strata and reference trees representation",
-    version="0.3.0",
+    version="0.3.1",
     packages=setuptools.find_namespace_packages(include=['forestdatamodel*'])
 )

--- a/tests/internal2mela_test.py
+++ b/tests/internal2mela_test.py
@@ -20,7 +20,7 @@ class Internal2MelaTest(unittest.TestCase):
         self.assertEqual(MelaTreeSpecies.OTHER_DECIDUOUS, result.species)
 
     def test_stand_conversion(self):
-        fixture = ForestStand()
+        fixture = ForestStand(geo_location=(6654200, 102598, 0.0, "EPSG:3067"))
         tree = ReferenceTree(species=TreeSpecies.SPRUCE, stand=fixture)
         stratum = TreeStratum(species=TreeSpecies.PINE, stand=fixture)
         fixture.reference_trees.append(tree)
@@ -28,3 +28,4 @@ class Internal2MelaTest(unittest.TestCase):
         result = mela_stand(fixture)
         self.assertEqual(MelaTreeSpecies.NORWAY_SPRUCE, result.reference_trees[0].species)
         self.assertEqual(MelaTreeSpecies.SCOTS_PINE, result.tree_strata[0].species)
+        self.assertEqual((6654.2, 102.598, 0.0, "EPSG:3067"), result.geo_location)


### PR DESCRIPTION
vmi-data-converter is no longer converting EPSG:3067 coordinates to kilometer precision. This is now responsibility of a mapper function in internal2mela.py

Also added variables from pymotti WeatherInfo to ForestStand, so they can be populated in sim-workbench pre-processing.