### PR TITLE
Add `COMMON_ALDER` to internal2mela

### DIFF
--- a/forestdatamodel/conversion/internal2mela.py
+++ b/forestdatamodel/conversion/internal2mela.py
@@ -16,6 +16,7 @@ species_map = {
     TreeSpecies.DOWNY_BIRCH: MelaTreeSpecies.DOWNY_BIRCH,
     TreeSpecies.ASPEN: MelaTreeSpecies.ASPEN,
     TreeSpecies.GREY_ALDER: MelaTreeSpecies.ALDER,
+    TreeSpecies.COMMON_ALDER: MelaTreeSpecies.ALDER,
     TreeSpecies.OTHER_CONIFEROUS: MelaTreeSpecies.OTHER_CONIFEROUS,
     TreeSpecies.OTHER_DECIDUOUS: MelaTreeSpecies.OTHER_DECIDUOUS,
     TreeSpecies.DOUGLAS_FIR: MelaTreeSpecies.OTHER_CONIFEROUS,

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ from setuptools import setup
 setup(
     name="forestdatamodel",
     description="Data classes and utilities for forest stand, tree strata and reference trees representation",
-    version="0.3.2",
+    version="0.3.4",
     packages=setuptools.find_namespace_packages(include=['forestdatamodel*'])
 )


### PR DESCRIPTION
`TreeSpecies.COMMON_ALDER` was missing from the conversion dict and crashed some test runs with pymotti on sim-workbench.

(Updated version from 0.3.2 to 0.3.4 since there seems to already be a 0.3.3 tag)